### PR TITLE
ci: harden dependabot config and catch toolchain drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,17 @@
 version: 2
 updates:
-  # Go modules - metrics backend
+  # --- Go modules: all extension backends + integration tests ---
+  # Single entry with multi-directory grouping so cross-cutting bumps
+  # (e.g. client-go) land in one PR instead of fanning out to 7 branches.
   - package-ecosystem: gomod
-    directory: /extensions/metrics/backend
+    directories:
+      - /extensions/metrics/backend
+      - /extensions/backups/backend
+      - /extensions/networking/backend
+      - /extensions/logs/backend
+      - /extensions/vulnerabilities/backend
+      - /extensions/events/backend
+      - /tests
     schedule:
       interval: monthly
     groups:
@@ -10,147 +19,59 @@ updates:
         patterns:
           - "*"
 
-  # Go modules - backups backend
-  - package-ecosystem: gomod
-    directory: /extensions/backups/backend
-    schedule:
-      interval: monthly
-    groups:
-      go-dependencies:
-        patterns:
-          - "*"
-
-  # Go modules - networking backend
-  - package-ecosystem: gomod
-    directory: /extensions/networking/backend
-    schedule:
-      interval: monthly
-    groups:
-      go-dependencies:
-        patterns:
-          - "*"
-
-  # Go modules - logs backend
-  - package-ecosystem: gomod
-    directory: /extensions/logs/backend
-    schedule:
-      interval: monthly
-    groups:
-      go-dependencies:
-        patterns:
-          - "*"
-
-  # Go modules - vulnerabilities backend
-  - package-ecosystem: gomod
-    directory: /extensions/vulnerabilities/backend
-    schedule:
-      interval: monthly
-    groups:
-      go-dependencies:
-        patterns:
-          - "*"
-
-  # Go modules - events backend
-  - package-ecosystem: gomod
-    directory: /extensions/events/backend
-    schedule:
-      interval: monthly
-    groups:
-      go-dependencies:
-        patterns:
-          - "*"
-
-  # Go modules - integration tests
-  - package-ecosystem: gomod
-    directory: /tests
-    schedule:
-      interval: monthly
-    groups:
-      go-dependencies:
-        patterns:
-          - "*"
-
-  # npm - metrics UI
+  # --- npm: extension UIs + shared package ---
+  # All UI bundles consume @argoplane/shared, which re-exports React types.
+  # If shared's @types/react / typescript drifts from the consumers, the
+  # whole extension tree fails to compile. Multi-directory grouping keeps
+  # them aligned; toolchain majors are ignored so they never auto-bump.
   - package-ecosystem: npm
-    directory: /extensions/metrics/ui
+    directories:
+      - /extensions/shared
+      - /extensions/metrics/ui
+      - /extensions/backups/ui
+      - /extensions/networking/ui
+      - /extensions/logs/ui
+      - /extensions/vulnerabilities/ui
+      - /extensions/events/ui
+      - /extensions/argoplane/ui
     schedule:
       interval: monthly
+    # React runtime is provided by ArgoCD (v3.x ships React 18) and marked
+    # external in webpack configs. Bumping our types ahead of ArgoCD is
+    # risky and pointless. TypeScript majors need hands-on migration too.
+    # Handle these manually, in lockstep with ArgoCD's bundled versions.
+    ignore:
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
+      # High-risk toolchain: separate PR so reviewers can scrutinize type
+      # + compiler changes without them hiding in a bulk bump.
+      react-toolchain:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "typescript"
       npm-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "typescript"
 
-  # npm - backups UI
-  - package-ecosystem: npm
-    directory: /extensions/backups/ui
-    schedule:
-      interval: monthly
-    groups:
-      npm-dependencies:
-        patterns:
-          - "*"
-
-  # npm - networking UI
-  - package-ecosystem: npm
-    directory: /extensions/networking/ui
-    schedule:
-      interval: monthly
-    groups:
-      npm-dependencies:
-        patterns:
-          - "*"
-
-  # npm - logs UI
-  - package-ecosystem: npm
-    directory: /extensions/logs/ui
-    schedule:
-      interval: monthly
-    groups:
-      npm-dependencies:
-        patterns:
-          - "*"
-
-  # npm - vulnerabilities UI
-  - package-ecosystem: npm
-    directory: /extensions/vulnerabilities/ui
-    schedule:
-      interval: monthly
-    groups:
-      npm-dependencies:
-        patterns:
-          - "*"
-
-  # npm - events UI
-  - package-ecosystem: npm
-    directory: /extensions/events/ui
-    schedule:
-      interval: monthly
-    groups:
-      npm-dependencies:
-        patterns:
-          - "*"
-
-  # npm - shared package
-  - package-ecosystem: npm
-    directory: /extensions/shared
-    schedule:
-      interval: monthly
-    groups:
-      npm-dependencies:
-        patterns:
-          - "*"
-
-  # npm - argoplane coordinator UI
-  - package-ecosystem: npm
-    directory: /extensions/argoplane/ui
-    schedule:
-      interval: monthly
-    groups:
-      npm-dependencies:
-        patterns:
-          - "*"
-
-  # npm - docs site
+  # --- npm: docs site (SvelteKit, independent stack) ---
   - package-ecosystem: npm
     directory: /services/docs
     schedule:
@@ -160,9 +81,17 @@ updates:
         patterns:
           - "*"
 
-  # Docker - metrics backend
+  # --- Docker: all backend Dockerfiles + init container + docs ---
   - package-ecosystem: docker
-    directory: /extensions/metrics/backend
+    directories:
+      - /extensions/metrics/backend
+      - /extensions/backups/backend
+      - /extensions/networking/backend
+      - /extensions/logs/backend
+      - /extensions/vulnerabilities/backend
+      - /extensions/events/backend
+      - /deploy/docker
+      - /services/docs
     schedule:
       interval: monthly
     groups:
@@ -170,77 +99,7 @@ updates:
         patterns:
           - "*"
 
-  # Docker - backups backend
-  - package-ecosystem: docker
-    directory: /extensions/backups/backend
-    schedule:
-      interval: monthly
-    groups:
-      docker-dependencies:
-        patterns:
-          - "*"
-
-  # Docker - networking backend
-  - package-ecosystem: docker
-    directory: /extensions/networking/backend
-    schedule:
-      interval: monthly
-    groups:
-      docker-dependencies:
-        patterns:
-          - "*"
-
-  # Docker - logs backend
-  - package-ecosystem: docker
-    directory: /extensions/logs/backend
-    schedule:
-      interval: monthly
-    groups:
-      docker-dependencies:
-        patterns:
-          - "*"
-
-  # Docker - vulnerabilities backend
-  - package-ecosystem: docker
-    directory: /extensions/vulnerabilities/backend
-    schedule:
-      interval: monthly
-    groups:
-      docker-dependencies:
-        patterns:
-          - "*"
-
-  # Docker - events backend
-  - package-ecosystem: docker
-    directory: /extensions/events/backend
-    schedule:
-      interval: monthly
-    groups:
-      docker-dependencies:
-        patterns:
-          - "*"
-
-  # Docker - UI extensions init container
-  - package-ecosystem: docker
-    directory: /deploy/docker
-    schedule:
-      interval: monthly
-    groups:
-      docker-dependencies:
-        patterns:
-          - "*"
-
-  # Docker - docs site
-  - package-ecosystem: docker
-    directory: /services/docs
-    schedule:
-      interval: monthly
-    groups:
-      docker-dependencies:
-        patterns:
-          - "*"
-
-  # GitHub Actions
+  # --- GitHub Actions ---
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/hack/check-extension-consistency.sh
+++ b/hack/check-extension-consistency.sh
@@ -107,6 +107,43 @@ for dockerfile in services/*/Dockerfile; do
   echo ""
 done
 
+# --- Toolchain version alignment ---
+# @argoplane/shared re-exports React-typed components that every ui bundle
+# imports. If @types/react, react, or typescript drift between shared and a
+# consumer, TS compilation breaks with cryptic JSX errors. Catch it here.
+echo "Checking toolchain version alignment (@types/react, react, typescript)..."
+extract_version() {
+  # $1=file, $2=dep name. Reads "dep": "^x.y.z" from dependencies or
+  # devDependencies. Strips leading ^ ~ = > < and surrounding whitespace.
+  local file="$1"
+  local dep="$2"
+  { grep -E "\"${dep}\"[[:space:]]*:" "$file" 2>/dev/null || true; } \
+    | head -n1 \
+    | sed -E 's|.*"'"${dep}"'"[[:space:]]*:[[:space:]]*"([^"]+)".*|\1|' \
+    | sed -E 's|^[\^~=><[:space:]]+||'
+}
+
+SHARED_PKG="extensions/shared/package.json"
+for dep in "@types/react" "react" "typescript"; do
+  shared_ver=$(extract_version "$SHARED_PKG" "$dep")
+  if [ -z "$shared_ver" ]; then
+    continue
+  fi
+  shared_major="${shared_ver%%.*}"
+  for pkg in extensions/*/ui/package.json; do
+    ver=$(extract_version "$pkg" "$dep")
+    if [ -z "$ver" ]; then
+      continue
+    fi
+    major="${ver%%.*}"
+    if [ "$major" != "$shared_major" ]; then
+      echo -e "${RED}DRIFT${NC}: $dep major differs: $SHARED_PKG=$shared_ver vs $pkg=$ver"
+      ERRORS=$((ERRORS + 1))
+    fi
+  done
+done
+echo ""
+
 if [ $ERRORS -gt 0 ]; then
   echo -e "${RED}Found $ERRORS consistency issues.${NC}"
   echo ""


### PR DESCRIPTION
- Group npm updates across shared + all extension UIs so @types/react, react, and typescript bumps land in one cross-directory PR
- Split react-toolchain (react, react-dom, @types/react*, typescript) into its own group, separate from bulk dependency bumps
- Ignore majors on react-toolchain packages; ArgoCD v3 ships React 18 and these need manual coordination with the host runtime
- Consolidate gomod and docker entries via multi-directory lists
- Extend check-extension-consistency.sh to flag @types/react / react / typescript major-version drift between shared and extension UIs