### PR TITLE
chore(dependabot): add 7-day cooldown to all update blocks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       - /tests
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       go-dependencies:
         patterns:
@@ -36,6 +38,8 @@ updates:
       - /extensions/argoplane/ui
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     # React runtime is provided by ArgoCD (v3.x ships React 18) and marked
     # external in webpack configs. Bumping our types ahead of ArgoCD is
     # risky and pointless. TypeScript majors need hands-on migration too.
@@ -76,6 +80,8 @@ updates:
     directory: /services/docs
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       npm-dependencies:
         patterns:
@@ -94,6 +100,8 @@ updates:
       - /services/docs
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       docker-dependencies:
         patterns:
@@ -104,6 +112,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## What

Adds a 7-day cooldown (`cooldown: { default-days: 7 }`) to every `updates` block in `dependabot.yml`.

## Why

Most malicious package releases (typosquats, hijacked maintainers, malicious post-install) are detected and pulled within 24-72h. A 7-day cooldown keeps us out of that danger window for routine version bumps. **Security updates are exempt from cooldown**, so CVE fixes still land immediately.

7 days is the cross-tool consensus value (Dependabot / Renovate `minimumReleaseAge` / npm `min-release-age`). Part of an org-wide rollout across all repos using Dependabot.

> Note: for `gomod` / `github-actions` / `docker`, Dependabot keys cooldown off the git tag commit date rather than release date, so treat it as defense-in-depth rather than airtight. See dependabot/dependabot-core#13078.