### PR TITLE
build(ui): target ArgoCD 3.5.2 (React 19)

### DIFF
--- a/.claude/rules/react.md
+++ b/.claude/rules/react.md
@@ -5,7 +5,7 @@
 ArgoCD extensions run inside ArgoCD's React runtime. React is provided globally by ArgoCD. Do not bundle React. Configure webpack/vite externals:
 
 ```javascript
-externals: { react: "React", "react-dom": "ReactDOM" }
+externals: { react: "React", "react-dom": "ReactDOM", "react/jsx-runtime": "ReactJSXRuntime" }
 ```
 
 ## Extension Registration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Every ArgoPlane extension follows the same pattern:
 
 ### Key Components
 
-- **ArgoCD v3.3.3**: GitOps engine, UI host, RBAC, proxy extension routing
+- **ArgoCD v3.5.2**: GitOps engine, UI host, RBAC, proxy extension routing
 - **Prometheus**: Metrics and alerts (metrics + alerts extensions)
 - **Loki**: Log aggregation (logs extension)
 - **Cilium/Hubble**: Network visibility (networking extension)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # --- Configuration ---
 CLUSTER_NAME    ?= argoplane-dev
-ARGOCD_VERSION  ?= v3.3.3
+ARGOCD_VERSION  ?= v3.5.2
 ARGOCD_NS       := argocd
 KIND_CONFIG     := hack/kind-config.yaml
 EXTENSIONS      := metrics networking logs vulnerabilities events

--- a/extensions/argoplane/ui/package-lock.json
+++ b/extensions/argoplane/ui/package-lock.json
@@ -11,7 +11,7 @@
         "@argoplane/shared": "file:../../shared"
       },
       "devDependencies": {
-        "@types/react": "^18.2.0",
+        "@types/react": "^19.2.18",
         "ts-loader": "^9.6.2",
         "typescript": "^5.4.0",
         "webpack": "^5.108.4",
@@ -22,11 +22,11 @@
       "name": "@argoplane/shared",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/react": "^18.3.31",
+        "@types/react": "^19.2.18",
         "typescript": "^5.4.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^19.0.0"
       }
     },
     "node_modules/@argoplane/shared": {
@@ -117,21 +117,13 @@
         "undici-types": "~8.3.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },

--- a/extensions/argoplane/ui/package.json
+++ b/extensions/argoplane/ui/package.json
@@ -11,7 +11,7 @@
     "@argoplane/shared": "file:../../shared"
   },
   "devDependencies": {
-    "@types/react": "^18.2.0",
+    "@types/react": "^19.2.18",
     "ts-loader": "^9.6.2",
     "typescript": "^5.4.0",
     "webpack": "^5.108.4",

--- a/extensions/argoplane/ui/webpack.config.js
+++ b/extensions/argoplane/ui/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
   externals: {
     react: 'React',
     'react-dom': 'ReactDOM',
+    'react/jsx-runtime': 'ReactJSXRuntime',
   },
   module: {
     rules: [

--- a/extensions/events/ui/package-lock.json
+++ b/extensions/events/ui/package-lock.json
@@ -11,7 +11,7 @@
         "@argoplane/shared": "file:../../shared"
       },
       "devDependencies": {
-        "@types/react": "^18.2.0",
+        "@types/react": "^19.2.18",
         "css-loader": "^7.0.0",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.6.2",
@@ -24,11 +24,11 @@
       "name": "@argoplane/shared",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/react": "^18.3.31",
+        "@types/react": "^19.2.18",
         "typescript": "^5.4.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^19.0.0"
       }
     },
     "node_modules/@argoplane/shared": {
@@ -119,21 +119,13 @@
         "undici-types": "~8.3.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },

--- a/extensions/events/ui/package.json
+++ b/extensions/events/ui/package.json
@@ -11,7 +11,7 @@
     "@argoplane/shared": "file:../../shared"
   },
   "devDependencies": {
-    "@types/react": "^18.2.0",
+    "@types/react": "^19.2.18",
     "css-loader": "^7.0.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.6.2",

--- a/extensions/events/ui/webpack.config.js
+++ b/extensions/events/ui/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
   externals: {
     react: 'React',
     'react-dom': 'ReactDOM',
+    'react/jsx-runtime': 'ReactJSXRuntime',
   },
   module: {
     rules: [

--- a/extensions/logs/ui/package-lock.json
+++ b/extensions/logs/ui/package-lock.json
@@ -11,7 +11,7 @@
         "@argoplane/shared": "file:../../shared"
       },
       "devDependencies": {
-        "@types/react": "^18.2.0",
+        "@types/react": "^19.2.18",
         "css-loader": "^7.0.0",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.6.2",
@@ -24,11 +24,11 @@
       "name": "@argoplane/shared",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/react": "^18.3.31",
+        "@types/react": "^19.2.18",
         "typescript": "^5.4.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^19.0.0"
       }
     },
     "node_modules/@argoplane/shared": {
@@ -119,21 +119,13 @@
         "undici-types": "~8.3.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },

--- a/extensions/logs/ui/package.json
+++ b/extensions/logs/ui/package.json
@@ -11,7 +11,7 @@
     "@argoplane/shared": "file:../../shared"
   },
   "devDependencies": {
-    "@types/react": "^18.2.0",
+    "@types/react": "^19.2.18",
     "css-loader": "^7.0.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.6.2",

--- a/extensions/logs/ui/webpack.config.js
+++ b/extensions/logs/ui/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
   externals: {
     react: 'React',
     'react-dom': 'ReactDOM',
+    'react/jsx-runtime': 'ReactJSXRuntime',
   },
   module: {
     rules: [

--- a/extensions/metrics/ui/package-lock.json
+++ b/extensions/metrics/ui/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@argoplane/shared": "file:../../shared",
+        "react-is": "^19.2.8",
         "recharts": "^3.9.2"
       },
       "devDependencies": {
-        "@types/react": "^18.2.0",
+        "@types/react": "^19.2.18",
         "css-loader": "^7.0.0",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.6.2",
@@ -25,11 +26,11 @@
       "name": "@argoplane/shared",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/react": "^18.3.31",
+        "@types/react": "^19.2.18",
         "typescript": "^5.4.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^19.0.0"
       }
     },
     "node_modules/@argoplane/shared": {
@@ -221,21 +222,13 @@
         "undici-types": "~8.3.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
@@ -1603,11 +1596,10 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT",
-      "peer": true
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/extensions/metrics/ui/package.json
+++ b/extensions/metrics/ui/package.json
@@ -9,10 +9,11 @@
   },
   "dependencies": {
     "@argoplane/shared": "file:../../shared",
+    "react-is": "^19.2.8",
     "recharts": "^3.9.2"
   },
   "devDependencies": {
-    "@types/react": "^18.2.0",
+    "@types/react": "^19.2.18",
     "css-loader": "^7.0.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.6.2",

--- a/extensions/metrics/ui/webpack.config.js
+++ b/extensions/metrics/ui/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
   externals: {
     react: 'React',
     'react-dom': 'ReactDOM',
+    'react/jsx-runtime': 'ReactJSXRuntime',
   },
   module: {
     rules: [

--- a/extensions/networking/ui/package-lock.json
+++ b/extensions/networking/ui/package-lock.json
@@ -11,7 +11,7 @@
         "@argoplane/shared": "file:../../shared"
       },
       "devDependencies": {
-        "@types/react": "^18.2.0",
+        "@types/react": "^19.2.18",
         "css-loader": "^7.0.0",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.6.2",
@@ -24,11 +24,11 @@
       "name": "@argoplane/shared",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/react": "^18.3.31",
+        "@types/react": "^19.2.18",
         "typescript": "^5.4.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^19.0.0"
       }
     },
     "node_modules/@argoplane/shared": {
@@ -119,21 +119,13 @@
         "undici-types": "~8.3.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },

--- a/extensions/networking/ui/package.json
+++ b/extensions/networking/ui/package.json
@@ -11,7 +11,7 @@
     "@argoplane/shared": "file:../../shared"
   },
   "devDependencies": {
-    "@types/react": "^18.2.0",
+    "@types/react": "^19.2.18",
     "css-loader": "^7.0.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.6.2",

--- a/extensions/networking/ui/webpack.config.js
+++ b/extensions/networking/ui/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
   externals: {
     react: 'React',
     'react-dom': 'ReactDOM',
+    'react/jsx-runtime': 'ReactJSXRuntime',
   },
   module: {
     rules: [

--- a/extensions/shared/package-lock.json
+++ b/extensions/shared/package-lock.json
@@ -8,28 +8,20 @@
       "name": "@argoplane/shared",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/react": "^18.3.31",
+        "@types/react": "^19.2.18",
         "typescript": "^5.4.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^19.0.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
@@ -40,35 +32,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/extensions/shared/package.json
+++ b/extensions/shared/package.json
@@ -5,10 +5,10 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": "^19.0.0"
   },
   "devDependencies": {
-    "@types/react": "^18.3.31",
+    "@types/react": "^19.2.18",
     "typescript": "^5.4.0"
   }
 }

--- a/extensions/vulnerabilities/ui/package-lock.json
+++ b/extensions/vulnerabilities/ui/package-lock.json
@@ -11,7 +11,7 @@
         "@argoplane/shared": "file:../../shared"
       },
       "devDependencies": {
-        "@types/react": "^18.2.0",
+        "@types/react": "^19.2.18",
         "css-loader": "^7.0.0",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.6.2",
@@ -24,11 +24,11 @@
       "name": "@argoplane/shared",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/react": "^18.3.31",
+        "@types/react": "^19.2.18",
         "typescript": "^5.4.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^19.0.0"
       }
     },
     "node_modules/@argoplane/shared": {
@@ -119,21 +119,13 @@
         "undici-types": "~8.3.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },

--- a/extensions/vulnerabilities/ui/package.json
+++ b/extensions/vulnerabilities/ui/package.json
@@ -11,7 +11,7 @@
     "@argoplane/shared": "file:../../shared"
   },
   "devDependencies": {
-    "@types/react": "^18.2.0",
+    "@types/react": "^19.2.18",
     "css-loader": "^7.0.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.6.2",

--- a/extensions/vulnerabilities/ui/webpack.config.js
+++ b/extensions/vulnerabilities/ui/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
   externals: {
     react: 'React',
     'react-dom': 'ReactDOM',
+    'react/jsx-runtime': 'ReactJSXRuntime',
   },
   module: {
     rules: [

--- a/services/docs/src/routes/adoption/+page.svx
+++ b/services/docs/src/routes/adoption/+page.svx
@@ -65,7 +65,7 @@ Add the **logs**, **vulnerabilities**, and **events** extensions. Developers can
 </Accordion>
 
 <Accordion title="Does ArgoPlane work with ArgoCD v2?">
-  ArgoPlane targets ArgoCD v3.x. Some extensions may work with v2.x proxy extensions, but v3 is required for full functionality (system-level extensions, status panels, app view extensions).
+  ArgoPlane targets ArgoCD v3.5+ (tested against v3.5.2, which runs the React 19 UI). Earlier v3.x releases generally work since the bundles avoid version-specific React APIs, but they are not tested. v2.x is not supported: system-level extensions, status panels, and app view extensions require v3.
 </Accordion>
 
 <Accordion title="Can I write my own extensions?">

--- a/services/docs/src/routes/deployment/+page.svx
+++ b/services/docs/src/routes/deployment/+page.svx
@@ -15,7 +15,7 @@ ArgoPlane ships as a Helm chart that deploys extension backends alongside ArgoCD
 
 ## Prerequisites
 
-- ArgoCD v3.x installed and running
+- ArgoCD v3.5+ installed and running
 - `kubectl` access to the cluster
 - Helm 3.x
 - Backend dependencies installed per extension:

--- a/services/docs/src/routes/deployment/argocd-configuration/+page.svx
+++ b/services/docs/src/routes/deployment/argocd-configuration/+page.svx
@@ -498,6 +498,7 @@ Key changes in ArgoCD v3 that affect extension configuration:
 | Extensions require RBAC | Every extension needs `p, role:<role>, extensions, invoke, <name>, allow`. |
 | Annotation-based tracking | Resource tracking uses annotations by default, not labels. |
 | Health in Redis | Resource health is stored in Redis, not in Application status. |
+| React 19 UI (v3.5+) | UI extensions must externalize `react/jsx-runtime` (exposed as `window.ReactJSXRuntime`). ArgoPlane bundles already do. Custom extensions built against older ArgoCD may fail to load until rebuilt. |
 
 ## Troubleshooting
 

--- a/services/docs/src/routes/developing/ui-extensions/+page.svx
+++ b/services/docs/src/routes/developing/ui-extensions/+page.svx
@@ -12,7 +12,7 @@ ArgoCD extensions run inside ArgoCD's React runtime. React is provided globally 
 Configure webpack externals to use ArgoCD's React:
 
 ```javascript
-externals: { react: "React", "react-dom": "ReactDOM" }
+externals: { react: "React", "react-dom": "ReactDOM", "react/jsx-runtime": "ReactJSXRuntime" }
 ```
 
 The build output must be a single JS file matching `extension(.*)\.js`, built as IIFE or UMD (not ES modules).

--- a/services/docs/src/routes/getting-started/+page.svx
+++ b/services/docs/src/routes/getting-started/+page.svx
@@ -13,7 +13,7 @@ This guide walks you through installing ArgoPlane extensions in your ArgoCD clus
 
 ## Prerequisites
 
-- ArgoCD v3.x installed and running
+- ArgoCD v3.5+ installed and running
 - `kubectl` access to the cluster
 - Helm (for operator installations like Prometheus, Loki, Trivy Operator)
 


### PR DESCRIPTION
ArgoCD 3.5 upgrades the UI from React 16 to React 19 and requires extensions to externalize react/jsx-runtime, exposed by argocd-server as window.ReactJSXRuntime.

- externalize react/jsx-runtime in all extension webpack configs
- bump react-is to 19 in metrics so recharts matches React 19's element type symbol (the tree-shakeable ESM build now drops out of the bundle entirely)
- align @types/react and the shared react peer range with React 19
- bump dev ARGOCD_VERSION to v3.5.2, update docs and conventions