### PR TITLE
fix(docs): build image stage on native platform

### DIFF
--- a/services/docs/Dockerfile
+++ b/services/docs/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:26-alpine AS build
+# Build natively on the builder's platform; the vite output is arch-independent.
+# Building under QEMU emulation crashes V8/Rolldown with SIGILL on arm64.
+FROM --platform=$BUILDPLATFORM node:26-alpine AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
vite build crashes with SIGILL under QEMU arm64 emulation (V8 JIT and Rolldown's native binary). The build output is arch-independent JS, so run the build stage on BUILDPLATFORM and keep only the runtime stage multi-arch.